### PR TITLE
従業員削除機能の実装

### DIFF
--- a/src/main/java/com/example/demo/app/EmployeeController.java
+++ b/src/main/java/com/example/demo/app/EmployeeController.java
@@ -219,7 +219,7 @@ public class EmployeeController {
 			return "emp_list";  
 		}
 		
-		// 従業員削除画面への遷移
+		// 削除選択画面への遷移
 		@GetMapping("/emp_delete")
 		public String showEmpDelete(Employee employee, Model model) {
 			// 実際の従業員IDのリストをデータベースから取得
@@ -228,22 +228,26 @@ public class EmployeeController {
 		    return "emp_delete";
 		}
 		
-		// 登録画面から確認画面への遷移
+		// 削除選択から削除確認への遷移
 		@PostMapping("/emp_delete_confirm")
 		public String transitDeleteConfirm(Integer empId, Model model) {
-			if (empId == null) {
-		        model.addAttribute("errorMessage", "検索条件に該当する従業員は見つかりません");
-		        List<Employee> employees = employeeService.findAll();
-		        model.addAttribute("employees", employees);
-		        return "emp_delete"; 
-		    }
-			// 選択された従業員IDを元にデータベースから完全な従業員情報を取得
-		    Optional<Employee> fullEmployeeOpt = employeeService.findById(empId);
-		        model.addAttribute("employee", fullEmployeeOpt.get());
-		        return "emp_delete_confirm";
+			if (empId != null) {
+				//従業員IDが指定されている場合
+				//選択された従業員IDを元にデータベースから従業員情報を取得
+				Optional<Employee> fullEmployeeOpt = employeeService.findById(empId);
+				model.addAttribute("employee", fullEmployeeOpt.get());
+				return "emp_delete_confirm";
+			} else {
+				//従業員IDが指定されていない場合
+				model.addAttribute("errorMessage", "検索条件に該当する従業員は見つかりません");
+				//従業員の一覧を取得してモデルに追加
+				List<Employee> employees = employeeService.findAll();
+				model.addAttribute("employees", employees);
+				return "emp_delete"; 
+			}
 		}
 		
-		// 確認画面から完了画面への遷移
+		// 削除確認から削除完了への遷移
 		@PostMapping("/emp_delete_complete")
 		public String delete(Integer empId, Model model) {
 		    // データベースの従業員情報を削除

--- a/src/main/java/com/example/demo/app/EmployeeController.java
+++ b/src/main/java/com/example/demo/app/EmployeeController.java
@@ -29,7 +29,6 @@ public class EmployeeController {
 
 	private final EmployeeService employeeService;
 
-
 	public EmployeeController(EmployeeService employeeService) {
 		this.employeeService = employeeService;
 	}
@@ -87,7 +86,6 @@ public class EmployeeController {
     public String userLogout(HttpSession session, RedirectAttributes attributes) {
     	//userLogoutメソッドを呼び出す
     	employeeService.userLogout(session);
-    	
         // ログイン画面にリダイレクト
         return "redirect:/login";
     }
@@ -100,7 +98,6 @@ public class EmployeeController {
 //        if (user == null) {
 //        	return "redirect:/login";
 //        }
-        
         //従業員リストを取得
 		List<Employee> list = employeeService.findAll();
 		//DBから取得した従業員情報が0件の場合、エラーメッセージを表示
@@ -118,7 +115,6 @@ public class EmployeeController {
 		model.addAttribute("employeeForm", new EmployeeForm());
 		return "emp_regist";
 	}
-
 	// 登録画面から確認画面への遷移
 	@PostMapping("/emp_regist_confirm")
 	public String transitConfirm(@Valid @ModelAttribute EmployeeForm employeeForm,BindingResult result, Model model) {
@@ -160,10 +156,9 @@ public class EmployeeController {
 		employee.setPassword(employeeForm.getPassword());
 		return employee;
 	}
-	
 	// 従業員検索画面への遷移
 		@GetMapping("/emp_search")
-		public String showEmpSearch(Employee employee, Model model) {
+		public String showEmpSearch() {
 			return "emp_search";
 		}
 	// 従業員検索画面での検索結果への遷移
@@ -246,7 +241,6 @@ public class EmployeeController {
 		        model.addAttribute("empIds", empIds);
 		        return "emp_delete"; 
 		    }
-			
 			// 選択された従業員IDを元にデータベースから完全な従業員情報を取得
 		    Optional<Employee> fullEmployeeOpt = employeeService.findById(selectedEmployee.getEmpId());
 		        model.addAttribute("employee", fullEmployeeOpt.get());

--- a/src/main/java/com/example/demo/app/EmployeeController.java
+++ b/src/main/java/com/example/demo/app/EmployeeController.java
@@ -2,7 +2,6 @@ package com.example.demo.app;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -225,33 +224,30 @@ public class EmployeeController {
 		public String showEmpDelete(Employee employee, Model model) {
 			// 実際の従業員IDのリストをデータベースから取得
 		    List<Employee> employees = employeeService.findAll();
-		    // すべての従業員からIDだけを取得
-		    List<Integer> empIds = employees.stream().map(Employee::getEmpId).collect(Collectors.toList());
-		    model.addAttribute("empIds", empIds);
+		    model.addAttribute("employees", employees);
 		    return "emp_delete";
 		}
 		
 		// 登録画面から確認画面への遷移
 		@PostMapping("/emp_delete_confirm")
-		public String transitDeleteConfirm(@ModelAttribute Employee selectedEmployee, Model model) {
-			if (selectedEmployee.getEmpId() == null) {
+		public String transitDeleteConfirm(Integer empId, Model model) {
+			if (empId == null) {
 		        model.addAttribute("errorMessage", "検索条件に該当する従業員は見つかりません");
 		        List<Employee> employees = employeeService.findAll();
-		        List<Integer> empIds = employees.stream().map(Employee::getEmpId).collect(Collectors.toList());
-		        model.addAttribute("empIds", empIds);
+		        model.addAttribute("employees", employees);
 		        return "emp_delete"; 
 		    }
 			// 選択された従業員IDを元にデータベースから完全な従業員情報を取得
-		    Optional<Employee> fullEmployeeOpt = employeeService.findById(selectedEmployee.getEmpId());
+		    Optional<Employee> fullEmployeeOpt = employeeService.findById(empId);
 		        model.addAttribute("employee", fullEmployeeOpt.get());
 		        return "emp_delete_confirm";
 		}
 		
 		// 確認画面から完了画面への遷移
 		@PostMapping("/emp_delete_complete")
-		public String delete(@ModelAttribute Employee selectedEmployee, Model model) {
+		public String delete(Integer empId, Model model) {
 		    // データベースの従業員情報を削除
-		    employeeService.delete(selectedEmployee.getEmpId());
+		    employeeService.delete(empId);
 		    return "emp_delete_complete";
 		}
 }

--- a/src/main/java/com/example/demo/repository/EmployeeDao.java
+++ b/src/main/java/com/example/demo/repository/EmployeeDao.java
@@ -13,4 +13,5 @@ public interface EmployeeDao{
 	void insert(Employee employee);
 	Optional<Employee> findById(int empId);
 	List<Employee>findByName(String empName);
+	public int delete(int empId);
 }

--- a/src/main/java/com/example/demo/repository/EmployeeDaoImpl.java
+++ b/src/main/java/com/example/demo/repository/EmployeeDaoImpl.java
@@ -26,13 +26,10 @@ public class EmployeeDaoImpl implements EmployeeDao {
 		+ " FROM Employee " + " INNER JOIN Department ON Employee.dept_id = Department.dept_id";
 		//従業員一覧をMapのListで取得
 		List<Map<String, Object>> resultList = jdbcTemplate.queryForList(sql);
-
 		//return用の空のリストを用意	
 		List<Employee> list = new ArrayList<Employee>();
-
 		//resultListの中身を取り出し、resultに格納
 		for(Map<String,Object> result : resultList) {
-
 			Employee employee = new Employee();
 			employee.setEmpId((int)result.get("emp_id"));
 			employee.setEmpName((String)result.get("emp_name"));
@@ -41,11 +38,9 @@ public class EmployeeDaoImpl implements EmployeeDao {
 			employee.setBirthDate(birthDate.toLocalDate());
 			employee.setSalary((int)result.get("salary"));
 			employee.setDeptId((int)result.get("dept_id"));
-
 			Department department = new Department();
 			department.setDeptId((int)result.get("dept_id"));
 			department.setDeptName((String)result.get("dept_name"));
-
 			//EmployeeにDepartmentをセットしてテーブルを結合
 			employee.setDepartment(department);
 			//Employeeをlistに追加
@@ -67,10 +62,8 @@ public class EmployeeDaoImpl implements EmployeeDao {
 		employee.setSalary((int)result.get("salary"));
 		employee.setDeptId((int)result.get("dept_id"));
 		employee.setPassword((String)result.get("password"));
-
 		//employeeをOptionalでラップする
 		Optional<Employee> employeeOpt = Optional.ofNullable(employee);
-
 		return employeeOpt;
 	}
 
@@ -130,7 +123,6 @@ public class EmployeeDaoImpl implements EmployeeDao {
 		department.setDeptName((String)result.get("dept_name"));
 		//EmployeeにDepartmentをセットしてテーブルを結合
 		employee.setDepartment(department);
-		
 		Optional<Employee> searchEmployee = Optional.ofNullable(employee);
 		return searchEmployee;
 	};
@@ -141,7 +133,6 @@ public class EmployeeDaoImpl implements EmployeeDao {
 		String sql = "SELECT emp_id, emp_name, email, birth_date, salary, Employee.dept_id, password, Department.dept_name"
 				+ " FROM Employee INNER JOIN Department ON Employee.dept_id = Department.dept_id"
 				+ " WHERE emp_name = ? ";
-		
 		//合致した従業員情報をMapのListで取得
 		List<Map<String, Object>> resultList = jdbcTemplate.queryForList(sql, empName);
 		//return用の空のリストを用意	
@@ -159,7 +150,6 @@ public class EmployeeDaoImpl implements EmployeeDao {
 			Department department = new Department();
 			department.setDeptId((int)result.get("dept_id"));
 			department.setDeptName((String)result.get("dept_name"));
-
 			//EmployeeにDepartmentをセットしてテーブルを結合
 			employee.setDepartment(department);
 			list.add(employee);

--- a/src/main/java/com/example/demo/repository/EmployeeDaoImpl.java
+++ b/src/main/java/com/example/demo/repository/EmployeeDaoImpl.java
@@ -166,5 +166,8 @@ public class EmployeeDaoImpl implements EmployeeDao {
 		}
 		return list;
 	};
-
+	
+	public int delete(int empId) {
+		return jdbcTemplate.update("DELETE FROM Employee WHERE emp_id = ?", empId);
+	};
 }

--- a/src/main/java/com/example/demo/service/EmployeeService.java
+++ b/src/main/java/com/example/demo/service/EmployeeService.java
@@ -16,4 +16,5 @@ public interface EmployeeService {
 	public void userLogout(HttpSession session);
 	Optional<Employee> findById(int empId);
 	List<Employee>findByName(String empName);
+	public void delete(int empId);
 }

--- a/src/main/java/com/example/demo/service/EmployeeServiceImpl.java
+++ b/src/main/java/com/example/demo/service/EmployeeServiceImpl.java
@@ -83,4 +83,11 @@ public class EmployeeServiceImpl implements EmployeeService {
 			throw new EmployeeNotFoundException("検索条件に該当する従業員は見つかりません");
 		}
 	};
+
+	public void delete(int empId) {
+		//従業員情報を削除。従業員IDがなければ例外発生
+		if(dao.delete(empId)==0) {
+			throw new EmployeeNotFoundException("削除する従業員が見つかりません");
+		}
+	}
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -142,6 +142,7 @@ h2{
 
 .page-guide{
 	font-size: 20px;
+	margin-bottom: 20px;
 }
 
 .regist-confirm{
@@ -175,3 +176,7 @@ h2{
 	display:flex;
 	justify-content: center;
 }
+
+/********************************************
+ 従業員削除
+*********************************************/

--- a/src/main/resources/templates/emp_delete.html
+++ b/src/main/resources/templates/emp_delete.html
@@ -24,7 +24,7 @@
 							<td>
 								<select th:field="*{empId}" id="id-select">
 									<option value="">従業員IDを選択</option>
-								 	<option th:each="employee : ${employees}" th:value="${employee.empId}" th:text="${employee.empId}"></option>
+								 	<option th:each="employee : ${employees}" th:value="${employee.empId}" th:text ="${employee.empId + '_' + employee.empName}"></option>
 								</select>
 							</td>
 						</tr>

--- a/src/main/resources/templates/emp_delete.html
+++ b/src/main/resources/templates/emp_delete.html
@@ -24,7 +24,7 @@
 							<td>
 								<select th:field="*{empId}" id="id-select">
 									<option value="">従業員IDを選択</option>
-									<option th:each="id : ${empIds}" th:value="${id}" th:text="${id}"></option>
+								 	<option th:each="employee : ${employees}" th:value="${employee.empId}" th:text="${employee.empId}"></option>
 								</select>
 							</td>
 						</tr>

--- a/src/main/resources/templates/emp_delete.html
+++ b/src/main/resources/templates/emp_delete.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+<meta charset="UTF-8">
+<link
+	href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+<link th:href="@{/css/style.css}" rel="stylesheet" type="text/css">
+<title>従業員削除</title>
+</head>
+<body>
+	<div class="container">
+		<h1 class="page-title">従業削除</h1>
+		<div class="return-menu">
+			<a th:href="@{/StaffTrack/menu}"><button type="button">＜＜メニュー画面に戻る</button></a>
+		</div>
+		<div class="contents">
+			<form th:action="@{/StaffTrack/emp_delete_confirm}" th:object="${employee}" method="post">
+				<!-- <div class="error" th:if="${#fields.hasErrors('empId')}" th:errors="*{empId}"></div> -->
+				<div class="page-guide">削除したい従業員情報を入力してください</div>
+				<div class="error" th:if="${errorMessage}" th:text="${errorMessage}"></div>
+				<table class="regist-table">
+					<tbody>
+						<tr>
+							<th>従業員ID</th>
+							<td>
+								<select th:field="*{empId}" id="id-select">
+									<option value="">従業員IDを選択</option>
+									<option th:each="id : ${empIds}" th:value="${id}" th:text="${id}"></option>
+								</select>
+							</td>
+						</tr>
+					</tbody>
+				</table>　
+				<div>
+					<button type="submit" class="btn btn-primary">削除ページへ進む</button>
+				</div>
+			</form>
+		</div>
+	</div>
+</body>
+</html>

--- a/src/main/resources/templates/emp_delete.html
+++ b/src/main/resources/templates/emp_delete.html
@@ -15,7 +15,6 @@
 		</div>
 		<div class="contents">
 			<form th:action="@{/StaffTrack/emp_delete_confirm}" th:object="${employee}" method="post">
-				<!-- <div class="error" th:if="${#fields.hasErrors('empId')}" th:errors="*{empId}"></div> -->
 				<div class="page-guide">削除したい従業員情報を入力してください</div>
 				<div class="error" th:if="${errorMessage}" th:text="${errorMessage}"></div>
 				<table class="regist-table">

--- a/src/main/resources/templates/emp_delete_complete.html
+++ b/src/main/resources/templates/emp_delete_complete.html
@@ -10,7 +10,7 @@
 	<div class="container">
 		<h1 class="page-title">従業員削除</h1>
 		<div class="contents">
-			<div class="page-guide">以下の内容で削除しました</div>
+			<div class="page-guide">以下の内容を削除しました</div>
 			<table class="regist-table">
 				<tbody>
 					<tr>

--- a/src/main/resources/templates/emp_delete_complete.html
+++ b/src/main/resources/templates/emp_delete_complete.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+<meta charset="UTF-8">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+<link th:href="@{/css/style.css}" rel="stylesheet" type="text/css">
+<title>従業員削除完了</title>
+</head>
+<body>
+	<div class="container">
+		<h1 class="page-title">従業員削除</h1>
+		<div class="contents">
+			<div class="page-guide">以下の内容で削除しました</div>
+			<table class="regist-table">
+				<tbody>
+					<tr>
+						<th>従業員ID</th>
+						<td th:text="${employee.empId}"></td>
+					</tr>
+					<tr>
+						<th>従業員名</th>
+						<td th:text="${employee.empName}"></td>
+					</tr>
+					<tr>
+						<th>メールアドレス</th>
+						<td th:text="${employee.email}"></td>
+					</tr>
+					<tr>
+						<th>生年月日</th>
+						<td th:text="${employee.birthDate}"></td>
+					</tr>
+					<tr>
+						<th>給与</th>
+						<td th:text="${employee.salary}"></td>
+					</tr>
+					<tr>
+						<th>部署</th>
+						<td th:text="${employee.department.deptName}"></td>
+					</tr>
+				</tbody>
+			</table>
+			<div class="regist-confirm">
+				<a th:href="@{/StaffTrack/menu}"><button type="button" class="btn btn-light">メニューへ戻る</button></a>
+			</div>
+		</div>
+	</div>
+</body>
+</html>

--- a/src/main/resources/templates/emp_delete_confirm.html
+++ b/src/main/resources/templates/emp_delete_confirm.html
@@ -32,7 +32,7 @@
 					</tr>
 					<tr>
 						<th>給与</th>
-						 <td th:text="${employee.salary}"></td>
+						<td th:text="${employee.salary}"></td>
 					</tr>
 					<tr>
 						<th>部署</th>

--- a/src/main/resources/templates/emp_delete_confirm.html
+++ b/src/main/resources/templates/emp_delete_confirm.html
@@ -42,12 +42,6 @@
 			</table>
 			<form th:action="@{/StaffTrack/emp_delete_complete}" method="post">
 				<input type="hidden" th:value="${employee.empId}" name="empId" /> 
-				<input type="hidden" th:value="${employee.empName}" name="empName" />
-				<input type="hidden" th:value="${employee.email}" name="email" />
-				<input type="hidden" th:value="${employee.birthDate}" name="birthDate" />
-				<input type="hidden" th:value="${employee.salary}" name="salary" />
-				<input type="hidden" th:value="${employee.deptName}" name="deptName" />
-				<input type="hidden" th:value="${employee.password}" name="password" />
 				<div class="regist-confirm">
 					<button type="submit" class="btn btn-primary btn-regist">削除</button>
 					<a th:href="@{/StaffTrack/emp_delete}"><button type="button" class="btn btn-light btn-return">戻る</button></a>

--- a/src/main/resources/templates/emp_delete_confirm.html
+++ b/src/main/resources/templates/emp_delete_confirm.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+<meta charset="UTF-8">
+<link
+	href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+<link th:href="@{/css/style.css}" rel="stylesheet" type="text/css">
+<title>従業員削除確認</title>
+</head>
+<body>
+	<div class="container">
+		<h1 class="page-title">従業員削除</h1>
+		<div class="contents">
+			<div class="page-guide">以下の内容で削除しますか？</div>
+			<table class="regist-table">
+				<tbody>
+					<tr>
+						<th>従業員ID</th>
+						<td th:text="${employee.empId}"></td>
+					</tr>
+					<tr>
+						<th>従業員名</th>
+						<td th:text="${employee.empName}"></td>
+					</tr>
+					<tr>
+						<th>メールアドレス</th>
+						<td th:text="${employee.email}"></td>
+					</tr>
+					<tr>
+						<th>生年月日</th>
+						<td th:text="${employee.birthDate}"></td>
+					</tr>
+					<tr>
+						<th>給与</th>
+						 <td th:text="${employee.salary}"></td>
+					</tr>
+					<tr>
+						<th>部署</th>
+						<td th:text="${employee.department.deptName}"></td>
+					</tr>
+				</tbody>
+			</table>
+			<form th:action="@{/StaffTrack/emp_delete_complete}" method="post">
+				<input type="hidden" th:value="${employee.empId}" name="empId" /> 
+				<input type="hidden" th:value="${employee.empName}" name="empName" />
+				<input type="hidden" th:value="${employee.email}" name="email" />
+				<input type="hidden" th:value="${employee.birthDate}" name="birthDate" />
+				<input type="hidden" th:value="${employee.salary}" name="salary" />
+				<input type="hidden" th:value="${employee.deptName}" name="deptName" />
+				<input type="hidden" th:value="${employee.password}" name="password" />
+				<div class="regist-confirm">
+					<button type="submit" class="btn btn-primary btn-regist">削除</button>
+					<a th:href="@{/StaffTrack/emp_delete}"><button type="button" class="btn btn-light btn-return">戻る</button></a>
+				</div>
+			</form>
+		</div>
+	</div>
+</body>
+</html>

--- a/src/main/resources/templates/emp_delete_confirm.html
+++ b/src/main/resources/templates/emp_delete_confirm.html
@@ -11,7 +11,7 @@
 	<div class="container">
 		<h1 class="page-title">従業員削除</h1>
 		<div class="contents">
-			<div class="page-guide">以下の内容で削除しますか？</div>
+			<div class="page-guide">以下の内容を削除しますか？</div>
 			<table class="regist-table">
 				<tbody>
 					<tr>

--- a/src/main/resources/templates/emp_list.html
+++ b/src/main/resources/templates/emp_list.html
@@ -36,7 +36,7 @@
 						<th>生年月日</th>
 						<th>給与</th>
 						<th>部署名</th>
-						<th>編集</th>
+						<th>変更</th>
 						<th>削除</th>
 					</tr>
 				</thead>
@@ -48,8 +48,13 @@
 						<td th:text="${employee.birthDate}"></td>
 						<td th:text="${employee.salary}"></td>
 						<td th:text="${employee.department.deptName}"></td>
-						<td><a th:href="@{/}"><button type="button" class="">編集</button></a></td>
-						<td><a th:href="@{/}"><button type="button" class="">削除</button></a></td>
+						<td><a th:href="@{#}"><button type="button" class="">変更</button></a></td>
+						<td>
+							<form method="POST" th:action="@{/StaffTrack/emp_delete_confirm}">
+								<input type="hidden" name="empId" th:value="${employee.empId}">
+								<input type="submit" value="削除">
+							</form> 
+						</td>
 					</tr>
 					<tr th:if="${searchEmployee != null}" th:object="${searchEmployee}">
 						<td th:text="*{empId}"></td>
@@ -58,8 +63,13 @@
 						<td th:text="*{birthDate}"></td>
 						<td th:text="*{salary}"></td>
 						<td th:text="*{department.deptName}"></td>
-						<td><a th:href="@{#}"><button type="button" class="">更新</button></a></td>
-						<td><a th:href="@{#}"><button type="button" class="">削除</button></a></td>
+						<td><a th:href="@{#}"><button type="button" class="">変更</button></a></td>
+						<td>
+							<form method="POST" th:action="@{/StaffTrack/emp_delete_confirm}">
+								<input type="hidden" name="empId" th:value="${employee.empId}">
+								<input type="submit" value="削除">
+							</form> 
+						</td>
 					</tr>
 				</tbody>
 			</table>

--- a/src/main/resources/templates/emp_search.html
+++ b/src/main/resources/templates/emp_search.html
@@ -37,7 +37,7 @@
 						<th>生年月日</th>
 						<th>給与</th>
 						<th>部署名</th>
-						<th>更新</th>
+						<th>変更</th>
 						<th>削除</th>
 					</tr>
 				</thead>
@@ -49,8 +49,13 @@
 						<td th:text="${employee.birthDate}"></td>
 						<td th:text="${employee.salary}"></td>
 						<td th:text="${employee.department.deptName}"></td>
-						<td><a th:href="@{#}"><button type="button" class="">更新</button></a></td>
-						<td><a th:href="@{#}"><button type="button" class="">削除</button></a></td>
+						<td><a th:href="@{#}"><button type="button" class="">変更</button></a></td>
+						<td>
+							<form method="POST" th:action="@{/StaffTrack/emp_delete_confirm}">
+								<input type="hidden" name="empId" th:value="${employee.empId}">
+								<input type="submit" value="削除">
+							</form> 
+						</td>
 					</tr>
 					<tr th:if="${searchEmployee != null}" th:object="${searchEmployee}">
 						<td th:text="*{empId}"></td>
@@ -59,8 +64,13 @@
 						<td th:text="*{birthDate}"></td>
 						<td th:text="*{salary}"></td>
 						<td th:text="*{department.deptName}"></td>
-						<td><a th:href="@{#}"><button type="button" class="">更新</button></a></td>
-						<td><a th:href="@{#}"><button type="button" class="">削除</button></a></td>
+						<td><a th:href="@{#}"><button type="button" class="">変更</button></a></td>
+						<td>
+							<form method="POST" th:action="@{/StaffTrack/emp_delete_confirm}">
+								<input type="hidden" name="empId" th:value="${employee.empId}">
+								<input type="submit" value="削除">
+							</form> 
+						</td>
 					</tr>
 				</tbody>
 			</table>

--- a/src/main/resources/templates/menu.html
+++ b/src/main/resources/templates/menu.html
@@ -26,6 +26,14 @@
 				<a th:href="@{/StaffTrack/emp_search}"><button type="button" class="btn btn-primary">従業員検索</button></a>
 			</div>
 			<br>
+			<div>
+				<a th:href="@{/StaffTrack/emp_delete}"><button type="button" class="btn btn-primary">従業員削除</button></a>
+			</div>
+			<br>
+			<div>
+				<a th:href="@{#}"><button type="button" class="btn btn-primary">従業員変更</button></a>
+			</div>
+			<br>
 			<div class="center-block">
 				<a th:href="@{/StaffTrack/login}"><button type="button" class="btn btn-danger">ログアウト</button></a>
 			</div>

--- a/src/test/java/com/example/demo/service/EmployeeDeleteUnitTest.java
+++ b/src/test/java/com/example/demo/service/EmployeeDeleteUnitTest.java
@@ -1,0 +1,75 @@
+package com.example.demo.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.demo.entity.Employee;
+import com.example.demo.repository.EmployeeDao;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("従業員削除の単体テスト")
+public class EmployeeDeleteUnitTest {
+	@Mock 
+	private EmployeeDao dao;
+
+	@InjectMocks
+	private EmployeeServiceImpl service;
+	
+	@Test
+	@DisplayName("従業員削除を実行すると、削除が成功するテスト")
+	public void testDeleteSuccess() {
+		// 任意の従業員IDを設定
+        int empId = 10000; 
+        // deleteメソッドが呼び出されたときに1を返すようにモックを設定
+        when(dao.delete(empId)).thenReturn(1);
+        // メソッドの実行
+        service.delete(empId);
+        // deleteメソッドが正確に1回呼び出されたか確認
+        verify(dao, times(1)).delete(empId);
+    }
+
+	@Test
+	@DisplayName("削除処理の完了後、データベースからも従業員情報が削除されるテスト")
+	public void testDeleteDB() {
+	    // 削除用の従業員情報を作成
+	    Employee employeed = new Employee();
+	    employeed.setEmpId(456789);
+	    
+	    // モックの設定
+	    doNothing().when(dao).insert(any(Employee.class));
+	    // findByEmpIdを実行すると空のOptionalが返される
+	    when(dao.findByEmpId(employeed.getEmpId())).thenReturn(Optional.empty()); 
+	    // deleteが呼び出されたとき、1を返すように設定
+	    when(dao.delete(employeed.getEmpId())).thenReturn(1); 
+	    // 従業員情報を登録
+	    service.insert(employeed);
+	    // 従業員情報の削除
+	    service.delete(employeed.getEmpId());
+	    // DBから同じIDの従業員を取得して、削除されているか確認
+	    Optional<Employee> optionalEmployee = service.findByEmpId(employeed.getEmpId());
+	    assertFalse(optionalEmployee.isPresent(), "従業員情報がデータベースから削除されていません");
+	}
+
+	@Test
+	@DisplayName("削除する従業員IDが取得できない場合、エラーメッセージが表示されるテスト")
+	void deleteWhenEmployeeNotFoundThrowsException() {
+		// 存在しない従業員IDを設定
+		int nonEmployeeId = 9999; 
+		// 従業員IDが存在しないとモックする
+		 when(dao.delete(nonEmployeeId)).thenReturn(0);
+        // deleteメソッドがEmployeeNotFoundExceptionをスローすることを検証
+        assertThrows(EmployeeNotFoundException.class, () -> {
+            service.delete(nonEmployeeId);
+        });
+    }
+}

--- a/src/test/java/com/example/demo/service/EmployeeDeleteUnitTest.java
+++ b/src/test/java/com/example/demo/service/EmployeeDeleteUnitTest.java
@@ -24,40 +24,40 @@ public class EmployeeDeleteUnitTest {
 
 	@InjectMocks
 	private EmployeeServiceImpl service;
-	
+
 	@Test
 	@DisplayName("従業員削除を実行すると、削除が成功するテスト")
 	public void testDeleteSuccess() {
 		// 任意の従業員IDを設定
-        int empId = 10000; 
-        // deleteメソッドが呼び出されたときに1を返すようにモックを設定
-        when(dao.delete(empId)).thenReturn(1);
-        // メソッドの実行
-        service.delete(empId);
-        // deleteメソッドが正確に1回呼び出されたか確認
-        verify(dao, times(1)).delete(empId);
-    }
+		int empId = 10000; 
+		// deleteメソッドが呼び出されたときに1を返すようにモックを設定
+		when(dao.delete(empId)).thenReturn(1);
+		// メソッドの実行
+		service.delete(empId);
+		// deleteメソッドが正確に1回呼び出されたか確認
+		verify(dao, times(1)).delete(empId);
+	}
 
 	@Test
 	@DisplayName("削除処理の完了後、データベースからも従業員情報が削除されるテスト")
 	public void testDeleteDB() {
-	    // 削除用の従業員情報を作成
-	    Employee employeed = new Employee();
-	    employeed.setEmpId(456789);
-	    
-	    // モックの設定
-	    doNothing().when(dao).insert(any(Employee.class));
-	    // findByEmpIdを実行すると空のOptionalが返される
-	    when(dao.findByEmpId(employeed.getEmpId())).thenReturn(Optional.empty()); 
-	    // deleteが呼び出されたとき、1を返すように設定
-	    when(dao.delete(employeed.getEmpId())).thenReturn(1); 
-	    // 従業員情報を登録
-	    service.insert(employeed);
-	    // 従業員情報の削除
-	    service.delete(employeed.getEmpId());
-	    // DBから同じIDの従業員を取得して、削除されているか確認
-	    Optional<Employee> optionalEmployee = service.findByEmpId(employeed.getEmpId());
-	    assertFalse(optionalEmployee.isPresent(), "従業員情報がデータベースから削除されていません");
+		// 削除用の従業員情報を作成
+		Employee employeed = new Employee();
+		employeed.setEmpId(456789);
+
+		// モックの設定
+		doNothing().when(dao).insert(any(Employee.class));
+		// findByEmpIdを実行すると空のOptionalが返される
+		when(dao.findByEmpId(employeed.getEmpId())).thenReturn(Optional.empty()); 
+		// deleteが呼び出されたとき、1を返すように設定
+		when(dao.delete(employeed.getEmpId())).thenReturn(1); 
+		// 従業員情報を登録
+		service.insert(employeed);
+		// 従業員情報の削除
+		service.delete(employeed.getEmpId());
+		// DBから同じIDの従業員を取得して、削除されているか確認
+		Optional<Employee> optionalEmployee = service.findByEmpId(employeed.getEmpId());
+		assertFalse(optionalEmployee.isPresent(), "従業員情報がデータベースから削除されていません");
 	}
 
 	@Test
@@ -66,10 +66,10 @@ public class EmployeeDeleteUnitTest {
 		// 存在しない従業員IDを設定
 		int nonEmployeeId = 9999; 
 		// 従業員IDが存在しないとモックする
-		 when(dao.delete(nonEmployeeId)).thenReturn(0);
-        // deleteメソッドがEmployeeNotFoundExceptionをスローすることを検証
-        assertThrows(EmployeeNotFoundException.class, () -> {
-            service.delete(nonEmployeeId);
-        });
-    }
+		when(dao.delete(nonEmployeeId)).thenReturn(0);
+		// deleteメソッドがEmployeeNotFoundExceptionをスローすることを検証
+		assertThrows(EmployeeNotFoundException.class, () -> {
+			service.delete(nonEmployeeId);
+		});
+	}
 }

--- a/src/test/java/com/example/demo/service/EmployeeDeleteUnitTest.java
+++ b/src/test/java/com/example/demo/service/EmployeeDeleteUnitTest.java
@@ -68,8 +68,12 @@ public class EmployeeDeleteUnitTest {
 		// 従業員IDが存在しないとモックする
 		when(dao.delete(nonEmployeeId)).thenReturn(0);
 		// deleteメソッドがEmployeeNotFoundExceptionをスローすることを検証
-		assertThrows(EmployeeNotFoundException.class, () -> {
-			service.delete(nonEmployeeId);
-		});
+		try {
+	        service.delete(nonEmployeeId);
+	        //例外がスローされない場合はテストが失敗
+	        fail("Expected an EmployeeNotFoundException to be thrown");
+	    } catch (EmployeeNotFoundException e) {
+	        // 予想通り例外がスローされテスト成功
+	    }
 	}
 }


### PR DESCRIPTION
## 変更の概要
以下のとおり従業員削除機能を実装した
* 従業員削除ページから削除する従業員を選択して削除を実行すると、データベースから情報が削除される
* 従業員一覧ページおよび従業員検索ページから削除ボタンを押すと、削除確認ページへ遷移する。削除実行後、データベースから情報が削除される

作業アウトライン
https://www.notion.so/divx/b3574bd119114b2d9ba6980ab4f252e2
## なぜこの変更をするのか
不要になった従業員情報を削除するため
## 実施したこと
 * [x] emp_delete.htmlの作成
 * [x] emp_delete_confirm.htmlの作成
 * [x] emp_delete_complete.htmlの作成
 * [x] emp_search.htmlの編集
 * [x] emp_list.htmlの編集
 * [x] menu.htmlの編集
 * [x] EmployeeController.javaの編集
 * [x] EmployeeDao.javaの編集
 * [x] EmployeeService.javaの編集
 * [x] 単体テストの作成
## 変更内容
### 動作確認
* 削除ページからの削除動作とエラーメッセージ
https://www.notion.so/divx/b3574bd119114b2d9ba6980ab4f252e2?pvs=4#723f9085f3f84ce2bb0c695fc88046ca
* 検索ページから削除動作
https://www.notion.so/divx/b3574bd119114b2d9ba6980ab4f252e2?pvs=4#9909e3429c7a426491a43f2a0d158d86
* 一覧ページからの削除動作
https://www.notion.so/divx/b3574bd119114b2d9ba6980ab4f252e2?pvs=4#ad47acad50104288b7116b23ba74771d
* 単体テスト
https://www.notion.so/divx/b3574bd119114b2d9ba6980ab4f252e2?pvs=4#461131d6c7104921a88ce3d7380a1c36

